### PR TITLE
Add "dumpallzones" command to dump all zones in BIND9 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Usage
            delzone      - delete an existing zone
            checkzone    - check that a zone is managed
            dumpzone     - dump a zone in BIND zonefile format
+           dumpallzones - dump all zones in BIND zonefile format
            zonestatus   - check whether a zone is updated on all NS
            nsstatus     - view a breakdown of zone update status by NS
            addmaster    - add new master server in domain zone
@@ -164,6 +165,23 @@ Dump an entire zone in BIND (RFC 1035) format, ideal for redirecting to a file.
     @           IN  SOA  ns1.cloudns.net. support.cloudns.net. 2017022309 7200 1800 1209600 3600
     @     3600  IN  NS   ns1.cloudns.net.
     ....
+
+### dumpallzones ###
+
+#### Description ####
+
+Similar to `dumpzone`, except it dumps **all** zones into a particular directory.
+This is useful for backing up your entire account. The output directory will be
+created if it does not already exist.
+
+#### Usage ####
+
+   $ cloudns_api.sh dumpzone <output directory>
+
+#### Example ####
+
+   $ cloudns_api.sh dumpzone /var/backup/zones/
+
 
 ### zonestatus ###
 

--- a/bin/cloudns_api.sh
+++ b/bin/cloudns_api.sh
@@ -641,6 +641,7 @@ function dump_all_zones() {
     if [ "${TYPE}" = "master" ]; then
       local ZONE=$( builtin echo "${RAW_ZONE}" | cut -d : -f 1 )
       dump_zone_impl $ZONE > "$OUTPUT_DIR/$ZONE.conf"
+      builtin echo "- ${ZONE}"
     fi;
   done;
 }


### PR DESCRIPTION
Adds a new `dumpallzones` command to dump all zones in BIND9 format. This is useful to backup an entire ClouDNS account.

Technically this *could* be accomplished in an external script by calling `cloudns_api.sh listzones` followed by `cloudns_api.sh dumpzone` for every zone. However, `dumpzone` itself uses `listzones` to determine if the specified zone is a valid zone in the account. This means that calling `dumpzone` 20 times also calls `listzones` 20 times! That's a waste of API calls, particular in this case where we know the zone names are valid.

To fix this, I split the `dump_zone` function into two separate functions: `dump_zone` that does all the validation, and `dump_zone_impl` that actually does the zone export. `dump_all_zones` uses `dump_zone_impl` directly, as it does not need to perform any of the validation.